### PR TITLE
fix: remove duplicate code in sql_servers's manager

### DIFF
--- a/src/spaceone/inventory/manager/container_instances/container_manager.py
+++ b/src/spaceone/inventory/manager/container_instances/container_manager.py
@@ -26,7 +26,7 @@ class ContainerInstancesManager(AzureManager):
                         - 'zones' : 'list'
                         - 'subscription_info' :  'dict'
                 Response:
-                    CloudServiceResponse (list) : list of azure application gateway data resource information
+                    CloudServiceResponse (list) : list of azure container instances data resource information
                     ErrorResourceResponse (list) : list of error resource information
         """
 
@@ -55,9 +55,9 @@ class ContainerInstancesManager(AzureManager):
 
                 # Update data info in Container's Raw Data
                 for container in container_instance_dict['containers']:
-                    start_time = container['instance_view']['current_state']['start_time']
-                    if start_time is not None:
-                        container_instance_dict['time_created'] = datetime_to_iso8601(start_time)
+                    launched_at = container['instance_view']['current_state']['start_time']
+                    if launched_at is not None:
+                        container_instance_dict['launched_at'] = datetime_to_iso8601(launched_at)
 
                 container_instance_dict.update({
                     'resource_group': self.get_resource_group_from_id(container_instance_id),
@@ -67,15 +67,12 @@ class ContainerInstancesManager(AzureManager):
                     'container_count_display': container_instance_dict['containers'].__len__()
                 })
 
-                # switch tags form and update tag info
-                _tags = self.convert_tag_format(container_instance_dict.get('tags', {}))
-
                 container_instance_data = ContainerInstance(container_instance_dict, strict=False)
                 container_instance_resource = ContainerInstanceResource({
                     'name': container_instance_data.name,
                     'account': container_instance_dict['subscription_id'],
                     'data': container_instance_data,
-                    'tags': _tags,
+                    'tags': container_instance_dict.get('tags', {}),
                     'region_code': container_instance_data.location,
                     'reference': ReferenceModel(container_instance_data.reference())
                 })

--- a/src/spaceone/inventory/manager/sql_servers/server_manager.py
+++ b/src/spaceone/inventory/manager/sql_servers/server_manager.py
@@ -128,22 +128,6 @@ class SQLServersManager(AzureManager):
                 sql_server_responses.append(SQLServerResponse({'resource': sql_server_resource}))
                 # _LOGGER.debug(f'[SQL SERVER INFO] {sql_server_resource.to_primitive()}')
 
-                for sql_database in sql_server_dict.get('databases', []):
-                    sql_database_data = SQLDatabase(sql_database, strict=False)
-                    sql_database_resource = SQLDatabaseResource({
-                        'data': sql_database_data,
-                        'region_code': sql_database_data.location,
-                        'reference': ReferenceModel(sql_database_data.reference()),
-                        'tags': _tags,
-                        'name': sql_database_data.name,
-                        'account': sql_database_data.subscription_id,
-                        'instance_type': sql_database_data.sku.tier,
-                        'instance_size': float(sql_database_data.max_size_gb),
-                        'launched_at': datetime_to_iso8601(sql_database_data.creation_date)
-                    })
-                    # _LOGGER.debug(f'[SQL DATABASE INFO IN SQL SERVER] {sql_database_resource.to_primitive()}')
-                    sql_server_responses.append(SQLDatabaseResponse({'resource': sql_database_resource}))
-
                 # Must set_region_code method for region collection
                 self.set_region_code(sql_server_data['location'])
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- remove duplicate code in sql_servers's manager
  1. collect SQL Servers in console
  2. see log in SpaceONE history menu
  3. you can see sql_database collected two times  
![스크린샷 2022-10-17 오전 11 21 01](https://user-images.githubusercontent.com/38625842/196075498-ec5ce4c5-c169-4615-bd8c-178583f68010.png)

   
### Known issue
